### PR TITLE
feat(query): Implement SQL parser and logical query planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,337 @@
 version = 4
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
 name = "common"
 version = "0.1.0"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "db"
 version = "0.1.0"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "insta"
+version = "1.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b66886d14d18d420ab5052cbff544fc5d34d0b2cdd35eb5976aaa10a4a472e5"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.105"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "query"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "common",
+ "insta",
+ "sqlparser",
+ "thiserror",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "sqlparser"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a875d8cd437cc8a97e9aeaeea352ec9a19aea99c23e9effb17757291de80b08"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "storage"
 version = "0.1.0"
+
+[[package]]
+name = "syn"
+version = "2.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "txn"
 version = "0.1.0"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
 name = "wal"
 version = "0.1.0"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "2"
-members = ["crates/common", "crates/db", "crates/storage", "crates/txn", "crates/wal"]
+members = [
+    "crates/common",
+    "crates/db",
+    "crates/storage",
+    "crates/txn",
+    "crates/wal",
+    "crates/query"
+]

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "query"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sqlparser = "0.52"
+thiserror = "2.0"
+anyhow = "1.0"
+common = { path = "../common" }
+
+[dev-dependencies]
+insta = "1.40"

--- a/crates/query/README.md
+++ b/crates/query/README.md
@@ -1,0 +1,74 @@
+# Query Processing Layer (Phase 2)
+
+This crate implements SQL parsing and logical query planning for the RDBMS project.
+
+## Architecture
+
+```
+SQL Text → Parser → AST → Planner → LogicalPlan → [Phase 3: Executor]
+```
+
+## Components
+
+### Parser (`parser.rs`)
+- Thin wrapper around `sqlparser-rs`
+- Handles SQL syntax validation
+- Produces Abstract Syntax Tree (AST)
+
+### Planner (`planner.rs`)
+- Translates AST to LogicalPlan
+- Performs semantic validation
+- Resolves table aliases
+- Validates column references
+
+### Logical Plan (`logical_plan.rs`)
+- Tree of relational algebra operators
+- Represents query execution semantics
+- Supports: Scan, Filter, Project, Join, Sort, Limit, Aggregate
+- Supports: Insert, Update, Delete, CreateTable, DropTable
+
+### Expression Trees (`expr.rs`)
+- Represents SQL expressions
+- Used in WHERE, SELECT, JOIN ON, etc.
+- Supports: columns, literals, binary/unary ops, functions
+
+### Schema (`schema.rs`)
+- Type system and metadata
+- Column definitions
+- Data flow information
+
+## Usage
+
+```rust
+use query::sql_to_logical_plan;
+
+let sql = "SELECT * FROM users WHERE age > 18";
+let plan = sql_to_logical_plan(sql)?;
+
+println!("{}", plan.explain());
+```
+
+## Supported SQL
+
+- `CREATE TABLE` with column types and constraints
+- `INSERT INTO` with multiple rows
+- `SELECT` with:
+  - WHERE clause
+  - JOIN (INNER, LEFT, RIGHT, FULL, CROSS)
+  - ORDER BY
+  - LIMIT/OFFSET
+  - GROUP BY + aggregates (COUNT, SUM, AVG, MIN, MAX)
+- `UPDATE` with WHERE clause
+- `DELETE` with WHERE clause
+- `DROP TABLE`
+
+## Testing
+
+```bash
+cargo test --package query
+cargo test --package query --test acceptance
+```
+
+## Next Phase
+
+Phase 3 will implement the physical execution engine that consumes these logical plans.

--- a/crates/query/src/expr.rs
+++ b/crates/query/src/expr.rs
@@ -1,0 +1,203 @@
+use crate::schema::DataType;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Column {
+        table: Option<String>,
+        name: String,
+    },
+    Literal(LiteralValue),
+    BinaryOp {
+        left: Box<Expr>,
+        op: BinaryOperator,
+        right: Box<Expr>,
+    },
+    UnaryOp {
+        op: UnaryOperator,
+        expr: Box<Expr>,
+    },
+    Function {
+        name: String,
+        args: Vec<Expr>,
+    },
+    Wildcard,
+    QualifiedWildcard {
+        table: String,
+    },
+    Cast {
+        expr: Box<Expr>,
+        target_type: DataType,
+    },
+    IsNull {
+        expr: Box<Expr>,
+        negated: bool,
+    },
+    Between {
+        expr: Box<Expr>,
+        low: Box<Expr>,
+        high: Box<Expr>,
+        negated: bool,
+    },
+    In {
+        expr: Box<Expr>,
+        list: Vec<Expr>,
+        negated: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LiteralValue {
+    Null,
+    Integer(i64),
+    Float(f64),
+    String(String),
+    Boolean(bool),
+}
+
+impl fmt::Display for LiteralValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LiteralValue::Null => write!(f, "NULL"),
+            LiteralValue::Integer(n) => write!(f, "{}", n),
+            LiteralValue::Float(n) => write!(f, "{}", n),
+            LiteralValue::String(s) => write!(f, "'{}'", s),
+            LiteralValue::Boolean(b) => write!(f, "{}", b),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryOperator {
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    Modulo,
+    Eq,
+    NotEq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+    And,
+    Or,
+    Concat,
+    Like,
+    NotLike,
+}
+
+impl fmt::Display for BinaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BinaryOperator::Plus => "+",
+            BinaryOperator::Minus => "-",
+            BinaryOperator::Multiply => "*",
+            BinaryOperator::Divide => "/",
+            BinaryOperator::Modulo => "%",
+            BinaryOperator::Eq => "=",
+            BinaryOperator::NotEq => "!=",
+            BinaryOperator::Lt => "<",
+            BinaryOperator::LtEq => "<=",
+            BinaryOperator::Gt => ">",
+            BinaryOperator::GtEq => ">=",
+            BinaryOperator::And => "AND",
+            BinaryOperator::Or => "OR",
+            BinaryOperator::Concat => "||",
+            BinaryOperator::Like => "LIKE",
+            BinaryOperator::NotLike => "NOT LIKE",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnaryOperator {
+    Not,
+    Minus,
+    Plus,
+}
+
+impl fmt::Display for UnaryOperator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            UnaryOperator::Not => "NOT",
+            UnaryOperator::Minus => "-",
+            UnaryOperator::Plus => "+",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl fmt::Display for Expr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Expr::Column { table, name } => {
+                if let Some(t) = table {
+                    write!(f, "{}.{}", t, name)
+                } else {
+                    write!(f, "{}", name)
+                }
+            }
+            Expr::Literal(lit) => write!(f, "{}", lit),
+            Expr::BinaryOp { left, op, right } => {
+                write!(f, "({} {} {})", left, op, right)
+            }
+            Expr::UnaryOp { op, expr } => {
+                write!(f, "({} {})", op, expr)
+            }
+            Expr::Function { name, args } => {
+                write!(f, "{}(", name)?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                }
+                write!(f, ")")
+            }
+            Expr::Wildcard => write!(f, "*"),
+            Expr::QualifiedWildcard { table } => write!(f, "{}.*", table),
+            Expr::Cast { expr, target_type } => {
+                write!(f, "CAST({} AS {:?})", expr, target_type)
+            }
+            Expr::IsNull { expr, negated } => {
+                if *negated {
+                    write!(f, "{} IS NOT NULL", expr)
+                } else {
+                    write!(f, "{} IS NULL", expr)
+                }
+            }
+            Expr::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => {
+                if *negated {
+                    write!(f, "{} NOT BETWEEN {} AND {}", expr, low, high)
+                } else {
+                    write!(f, "{} BETWEEN {} AND {}", expr, low, high)
+                }
+            }
+            Expr::In {
+                expr,
+                list,
+                negated,
+            } => {
+                if *negated {
+                    write!(f, "{} NOT IN (", expr)?;
+                } else {
+                    write!(f, "{} IN (", expr)?;
+                }
+                for (i, item) in list.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                write!(f, ")")
+            }
+        }
+    }
+}

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -1,0 +1,53 @@
+pub mod expr;
+pub mod logical_plan;
+pub mod parser;
+pub mod planner;
+pub mod schema;
+
+pub use expr::{BinaryOperator, Expr, LiteralValue, UnaryOperator};
+pub use logical_plan::{
+    AggregateExpr, AggregateFunction, Assignment, JoinType, LogicalPlan, SortExpr,
+};
+pub use parser::SqlParser;
+pub use planner::LogicalPlanner;
+pub use schema::{ColumnDef, DataType, DefaultValue, Field, Schema, TableSchema};
+
+use anyhow::Result;
+
+pub fn sql_to_logical_plan(sql: &str) -> Result<LogicalPlan> {
+    let parser = SqlParser::new();
+    let stmt = parser.parse_one(sql)?;
+    let mut planner = LogicalPlanner::new();
+    planner.plan_statement(stmt)
+}
+
+pub fn explain_sql(sql: &str) -> Result<String> {
+    let plan = sql_to_logical_plan(sql)?;
+    Ok(plan.explain())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_api_simple_select() {
+        let plan = sql_to_logical_plan("SELECT * FROM users").unwrap();
+        assert!(matches!(plan, LogicalPlan::Project { .. }));
+    }
+    #[test]
+    fn test_api_explain() {
+        let explanation = explain_sql("SELECT * FROM users WHERE age > 18").unwrap();
+        assert!(explanation.contains("Filter"));
+        assert!(explanation.contains("Scan"));
+    }
+
+    #[test]
+    fn test_dot_exporter() {
+        let plan = sql_to_logical_plan("SELECT * FROM users WHERE age > 18").unwrap();
+        let dot = plan.to_dot();
+        assert!(dot.contains("digraph"));
+        assert!(dot.contains("n1"));
+        assert!(dot.contains("->"));
+        println!("DOT output:\n{}", dot);
+    }
+}

--- a/crates/query/src/logical_plan.rs
+++ b/crates/query/src/logical_plan.rs
@@ -1,0 +1,629 @@
+use crate::expr::Expr;
+use crate::schema::{ColumnDef, DataType, Field, Schema};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogicalPlan {
+    Scan {
+        table_name: String,
+        alias: Option<String>,
+        schema: Option<Schema>,
+    },
+    Filter {
+        input: Box<LogicalPlan>,
+        predicate: Expr,
+    },
+    Project {
+        input: Box<LogicalPlan>,
+        expressions: Vec<Expr>,
+        aliases: Option<Vec<String>>,
+    },
+    Join {
+        left: Box<LogicalPlan>,
+        right: Box<LogicalPlan>,
+        join_type: JoinType,
+        condition: Option<Expr>,
+    },
+    Sort {
+        input: Box<LogicalPlan>,
+        sort_exprs: Vec<SortExpr>,
+    },
+    Limit {
+        input: Box<LogicalPlan>,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    },
+    Aggregate {
+        input: Box<LogicalPlan>,
+        group_by: Vec<Expr>,
+        aggregates: Vec<AggregateExpr>,
+    },
+    Insert {
+        table_name: String,
+        columns: Option<Vec<String>>,
+        values: Vec<Vec<Expr>>,
+        schema: Option<Schema>,
+    },
+    Update {
+        table_name: String,
+        assignments: Vec<Assignment>,
+        filter: Option<Expr>,
+        schema: Option<Schema>,
+    },
+    Delete {
+        table_name: String,
+        filter: Option<Expr>,
+        schema: Option<Schema>,
+    },
+    CreateTable {
+        table_name: String,
+        columns: Vec<ColumnDef>,
+        if_not_exists: bool,
+    },
+    DropTable {
+        table_name: String,
+        if_exists: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JoinType {
+    Inner,
+    Left,
+    Right,
+    Full,
+    Cross,
+}
+
+impl fmt::Display for JoinType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JoinType::Inner => write!(f, "INNER"),
+            JoinType::Left => write!(f, "LEFT"),
+            JoinType::Right => write!(f, "RIGHT"),
+            JoinType::Full => write!(f, "FULL"),
+            JoinType::Cross => write!(f, "CROSS"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Assignment {
+    pub column: String,
+    pub value: Expr,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SortExpr {
+    pub expr: Expr,
+    pub asc: bool,
+    pub nulls_first: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AggregateExpr {
+    pub func: AggregateFunction,
+    pub args: Vec<Expr>,
+    pub alias: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateFunction {
+    Count,
+    Sum,
+    Avg,
+    Min,
+    Max,
+}
+
+impl std::fmt::Display for AggregateFunction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AggregateFunction::Count => write!(f, "COUNT"),
+            AggregateFunction::Sum => write!(f, "SUM"),
+            AggregateFunction::Avg => write!(f, "AVG"),
+            AggregateFunction::Min => write!(f, "MIN"),
+            AggregateFunction::Max => write!(f, "MAX"),
+        }
+    }
+}
+
+impl LogicalPlan {
+    pub fn schema(&self) -> Schema {
+        match self {
+            LogicalPlan::Scan {
+                schema,
+                table_name: _,
+                alias,
+                ..
+            } => {
+                if let Some(s) = schema {
+                    if let Some(a) = alias {
+                        Schema::new(
+                            s.fields
+                                .iter()
+                                .map(|f| Field {
+                                    name: format!("{}.{}", a, f.name),
+                                    table: Some(a.clone()),
+                                    data_type: f.data_type.clone(),
+                                    nullable: f.nullable,
+                                })
+                                .collect(),
+                        )
+                    } else {
+                        s.clone()
+                    }
+                } else {
+                    Schema::empty()
+                }
+            }
+            LogicalPlan::Filter { input, .. } => input.schema(),
+            LogicalPlan::Project {
+                expressions,
+                aliases,
+                input: _,
+            } => {
+                Schema::new(
+                    expressions
+                        .iter()
+                        .enumerate()
+                        .map(|(i, expr)| {
+                            let name = if let Some(aliases) = aliases {
+                                aliases[i].clone()
+                            } else {
+                                format!("{}", expr)
+                            };
+                            Field {
+                                name,
+                                table: None,
+                                data_type: DataType::Text, // Simplified
+                                nullable: true,
+                            }
+                        })
+                        .collect(),
+                )
+            }
+            LogicalPlan::Join { left, right, .. } => {
+                let left_schema = left.schema();
+                let right_schema = right.schema();
+                let mut fields = left_schema.fields.clone();
+                fields.extend(right_schema.fields);
+                Schema::new(fields)
+            }
+            LogicalPlan::Sort { input, .. } => input.schema(),
+            LogicalPlan::Limit { input, .. } => input.schema(),
+            LogicalPlan::Aggregate { .. } => Schema::empty(),
+            LogicalPlan::Insert { schema: _, .. }
+            | LogicalPlan::Update { schema: _, .. }
+            | LogicalPlan::Delete { schema: _, .. } => Schema::new(vec![Field {
+                name: "rows_affected".to_string(),
+                table: None,
+                data_type: DataType::Integer,
+                nullable: false,
+            }]),
+            LogicalPlan::CreateTable { .. } | LogicalPlan::DropTable { .. } => {
+                Schema::new(vec![Field {
+                    name: "status".to_string(),
+                    table: None,
+                    data_type: DataType::Text,
+                    nullable: false,
+                }])
+            }
+        }
+    }
+
+    pub fn explain(&self) -> String {
+        self.explain_with_indent(0)
+    }
+    fn explain_with_indent(&self, indent: usize) -> String {
+        let prefix = "  ".repeat(indent);
+        let child_indent = indent + 1;
+
+        match self {
+            LogicalPlan::Scan {
+                table_name, alias, ..
+            } => {
+                if let Some(alias_name) = alias {
+                    format!("{}Scan: {} (alias: {})", prefix, table_name, alias_name)
+                } else {
+                    format!("{}Scan: {}", prefix, table_name)
+                }
+            }
+            LogicalPlan::Filter { input, predicate } => {
+                format!(
+                    "{}Filter: {}\n{}",
+                    prefix,
+                    predicate,
+                    input.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Project {
+                input,
+                expressions,
+                aliases,
+            } => {
+                let expr_str = if let Some(a) = aliases {
+                    expressions
+                        .iter()
+                        .zip(a.iter())
+                        .map(|(e, a)| format!("{} AS {}", e, a))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                } else {
+                    expressions
+                        .iter()
+                        .map(|e| format!("{}", e))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                format!(
+                    "{}Project: [{}]\n{}",
+                    prefix,
+                    expr_str,
+                    input.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Join {
+                left,
+                right,
+                join_type,
+                condition,
+            } => {
+                let cond_str = condition
+                    .as_ref()
+                    .map(|c| format!(" ON {}", c))
+                    .unwrap_or_default();
+                format!(
+                    "{}Join [{}]{}\n{}\n{}",
+                    prefix,
+                    join_type,
+                    cond_str,
+                    left.explain_with_indent(child_indent),
+                    right.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Sort { input, sort_exprs } => {
+                let sort_str = sort_exprs
+                    .iter()
+                    .map(|s| format!("{} {}", s.expr, if s.asc { "ASC" } else { "DESC" }))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{}Sort: [{}]\n{}",
+                    prefix,
+                    sort_str,
+                    input.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Limit {
+                input,
+                offset,
+                limit,
+            } => {
+                let limit_str = match (offset, limit) {
+                    (Some(o), Some(l)) => format!("OFFSET {} LIMIT {}", o, l),
+                    (Some(o), None) => format!("OFFSET {}", o),
+                    (None, Some(l)) => format!("LIMIT {}", l),
+                    (None, None) => "".to_string(),
+                };
+                format!(
+                    "{}Limit: {}\n{}",
+                    prefix,
+                    limit_str,
+                    input.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Aggregate {
+                input,
+                group_by,
+                aggregates,
+            } => {
+                let group_str = if group_by.is_empty() {
+                    "[]".to_string()
+                } else {
+                    format!(
+                        "[{}]",
+                        group_by
+                            .iter()
+                            .map(|e| format!("{}", e))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                let agg_str = aggregates
+                    .iter()
+                    .map(|a| format!("{:?}({:?})", a.func, a.args))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{}Aggregate: group_by={}, aggs=[{}]\n{}",
+                    prefix,
+                    group_str,
+                    agg_str,
+                    input.explain_with_indent(child_indent)
+                )
+            }
+            LogicalPlan::Insert {
+                table_name,
+                columns,
+                values,
+                ..
+            } => {
+                let col_str = columns
+                    .as_ref()
+                    .map(|c| format!("({})", c.join(", ")))
+                    .unwrap_or_else(|| "(all columns)".to_string());
+                format!(
+                    "{}Insert into {}{}: {} rows",
+                    prefix,
+                    table_name,
+                    col_str,
+                    values.len()
+                )
+            }
+            LogicalPlan::Update {
+                table_name,
+                assignments,
+                filter,
+                ..
+            } => {
+                let assign_str = assignments
+                    .iter()
+                    .map(|a| format!("{} = {}", a.column, a.value))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let filter_str = filter
+                    .as_ref()
+                    .map(|f| format!(" WHERE {}", f))
+                    .unwrap_or_default();
+                format!(
+                    "{}Update {}: SET {}{}",
+                    prefix, table_name, assign_str, filter_str
+                )
+            }
+            LogicalPlan::Delete {
+                table_name, filter, ..
+            } => {
+                let filter_str = filter
+                    .as_ref()
+                    .map(|f| format!(" WHERE {}", f))
+                    .unwrap_or_default();
+                format!("{}Delete from {}{}", prefix, table_name, filter_str)
+            }
+            LogicalPlan::CreateTable {
+                table_name,
+                columns,
+                if_not_exists,
+            } => {
+                let ine = if *if_not_exists { " IF NOT EXISTS" } else { "" };
+                format!(
+                    "{}CreateTable{} {}: {} columns",
+                    prefix,
+                    ine,
+                    table_name,
+                    columns.len()
+                )
+            }
+            LogicalPlan::DropTable {
+                table_name,
+                if_exists,
+            } => {
+                let ie = if *if_exists { " IF EXISTS" } else { "" };
+                format!("{}DropTable{} {}", prefix, ie, table_name)
+            }
+        }
+    }
+
+    pub fn to_dot(&self) -> String {
+        let mut output = String::new();
+        output.push_str("digraph LogicalPlan {\n");
+        output.push_str("  rankdir=TB;\n");
+        output
+            .push_str("  node [shape=box, style=\"rounded,filled\", fontname=\"Helvetica\"];\n\n");
+        self.write_dot_node(1, &mut output);
+        output.push_str("}\n");
+        output
+    }
+
+    fn write_dot_node(&self, node_id: usize, output: &mut String) -> usize {
+        let (label, children) = self.get_dot_info();
+        output.push_str(&format!(
+            "  n{} [label=\"{}\", fillcolor=lightblue];\n",
+            node_id, label
+        ));
+
+        let mut next_id = node_id + 1;
+        for child in children {
+            let child_id = next_id;
+            next_id = child.write_dot_node(child_id, output);
+            output.push_str(&format!("  n{} -> n{};\n", node_id, child_id));
+        }
+        next_id
+    }
+
+    fn get_dot_info(&self) -> (String, Vec<&LogicalPlan>) {
+        match self {
+            LogicalPlan::Scan {
+                table_name, alias, ..
+            } => {
+                let label = format!(
+                    "Scan: {}{}",
+                    table_name,
+                    alias
+                        .as_ref()
+                        .map(|a| format!(" AS {}", a))
+                        .unwrap_or_default()
+                );
+                (label, vec![])
+            }
+            LogicalPlan::Filter { predicate, input } => {
+                let label = format!("Filter: {}", predicate);
+                (label, vec![input])
+            }
+            LogicalPlan::Project {
+                expressions,
+                aliases,
+                input,
+            } => {
+                let exprs = expressions
+                    .iter()
+                    .enumerate()
+                    .map(|(i, e)| {
+                        if let Some(aliases) = aliases {
+                            format!("{} AS {}", e, aliases[i])
+                        } else {
+                            format!("{}", e)
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let label = format!("Project: [{}]", exprs);
+                (label, vec![input])
+            }
+            LogicalPlan::Join {
+                left,
+                right,
+                join_type,
+                condition,
+            } => {
+                let cond = condition
+                    .as_ref()
+                    .map(|c| format!(" ON {}", c))
+                    .unwrap_or_default();
+                let label = format!("{:?}Join{}", join_type, cond);
+                (label, vec![left, right])
+            }
+            LogicalPlan::Sort { sort_exprs, input } => {
+                let sort_str = sort_exprs
+                    .iter()
+                    .map(|s| format!("{} {}", s.expr, if s.asc { "ASC" } else { "DESC" }))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let label = format!("Sort: [{}]", sort_str);
+                (label, vec![input])
+            }
+            LogicalPlan::Limit {
+                offset,
+                limit,
+                input,
+            } => {
+                let limit_str = match (offset, limit) {
+                    (Some(o), Some(l)) => format!("OFFSET {} LIMIT {}", o, l),
+                    (Some(o), None) => format!("OFFSET {}", o),
+                    (None, Some(l)) => format!("LIMIT {}", l),
+                    (None, None) => "".to_string(),
+                };
+                let label = format!("Limit: {}", limit_str);
+                (label, vec![input])
+            }
+            LogicalPlan::Aggregate {
+                group_by,
+                aggregates,
+                input,
+            } => {
+                let group_str = if group_by.is_empty() {
+                    "".to_string()
+                } else {
+                    format!(
+                        "GROUP BY {}",
+                        group_by
+                            .iter()
+                            .map(|g| format!("{}", g))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                let agg_str = aggregates
+                    .iter()
+                    .map(|a| {
+                        format!(
+                            "{}({})",
+                            a.func,
+                            a.args
+                                .iter()
+                                .map(|arg| format!("{}", arg))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let label = format!(
+                    "Aggregate\n{}{}",
+                    group_str,
+                    if !agg_str.is_empty() {
+                        format!("\nAggregates: {}", agg_str)
+                    } else {
+                        "".to_string()
+                    }
+                );
+                (label, vec![input])
+            }
+            LogicalPlan::Insert {
+                table_name,
+                columns,
+                values,
+                ..
+            } => {
+                let col_str = columns
+                    .as_ref()
+                    .map(|c| format!("({})", c.join(", ")))
+                    .unwrap_or_default();
+                let val_count = values.first().map(|v| v.len()).unwrap_or(0);
+                let label = format!(
+                    "Insert into {}{}\n{} rows, {} values each",
+                    table_name,
+                    col_str,
+                    values.len(),
+                    val_count
+                );
+                (label, vec![])
+            }
+            LogicalPlan::Update {
+                table_name,
+                assignments,
+                filter,
+                ..
+            } => {
+                let assign_str = assignments
+                    .iter()
+                    .map(|a| format!("{} = {}", a.column, a.value))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let filter_str = filter
+                    .as_ref()
+                    .map(|f| format!(" WHERE {}", f))
+                    .unwrap_or_default();
+                let label = format!("Update {}\nSet: {}{}", table_name, assign_str, filter_str);
+                (label, vec![])
+            }
+            LogicalPlan::Delete {
+                table_name, filter, ..
+            } => {
+                let filter_str = filter
+                    .as_ref()
+                    .map(|f| format!(" WHERE {}", f))
+                    .unwrap_or_default();
+                let label = format!("Delete from {}{}", table_name, filter_str);
+                (label, vec![])
+            }
+            LogicalPlan::CreateTable {
+                table_name,
+                columns,
+                ..
+            } => {
+                let col_str = columns
+                    .iter()
+                    .map(|c| format!("{}: {:?}", c.name, c.data_type))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let label = format!("CreateTable: {}\n{}", table_name, col_str);
+                (label, vec![])
+            }
+            LogicalPlan::DropTable { table_name, .. } => {
+                let label = format!("DropTable: {}", table_name);
+                (label, vec![])
+            }
+        }
+    }
+}

--- a/crates/query/src/parser.rs
+++ b/crates/query/src/parser.rs
@@ -1,0 +1,74 @@
+use sqlparser::ast::Statement;
+use sqlparser::dialect::GenericDialect;
+use sqlparser::parser::{Parser, ParserError};
+
+pub struct SqlParser {
+    dialect: GenericDialect,
+}
+
+impl SqlParser {
+    pub fn new() -> Self {
+        Self {
+            dialect: GenericDialect {},
+        }
+    }
+    pub fn parse(&self, sql: &str) -> Result<Vec<Statement>, ParserError> {
+        Parser::parse_sql(&self.dialect, sql)
+    }
+    pub fn parse_one(&self, sql: &str) -> Result<Statement, ParserError> {
+        let statements = self.parse(sql)?;
+        if statements.is_empty() {
+            return Err(ParserError::ParserError(
+                "No SQL statement found".to_string(),
+            ));
+        }
+        if statements.len() > 1 {
+            return Err(ParserError::ParserError(
+                "Expected single statement, found multiple".to_string(),
+            ));
+        }
+        Ok(statements.into_iter().next().unwrap())
+    }
+}
+
+impl Default for SqlParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_parse_simple_select() {
+        let parser = SqlParser::new();
+        let result = parser.parse_one("SELECT * FROM users");
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn test_parse_invalid_sql() {
+        let parser = SqlParser::new();
+        let result = parser.parse_one("SELECT FROM WHERE");
+        assert!(result.is_err());
+    }
+    #[test]
+    fn test_parse_join() {
+        let parser = SqlParser::new();
+        let result =
+            parser.parse_one("SELECT * FROM Event e JOIN TicketType t ON e.id = t.eventId");
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn test_parse_multiple_statements() {
+        let parser = SqlParser::new();
+        let result = parser.parse_one("SELECT 1; SELECT 2;");
+        assert!(result.is_err());
+    }
+    #[test]
+    fn test_parse_empty() {
+        let parser = SqlParser::new();
+        let result = parser.parse_one("");
+        assert!(result.is_err());
+    }
+}

--- a/crates/query/src/planner.rs
+++ b/crates/query/src/planner.rs
@@ -1,0 +1,709 @@
+// Fixed planner.rs with correct sqlparser 0.52 API
+
+use crate::expr::{
+    BinaryOperator as LocalBinaryOperator, Expr as LocalExpr, LiteralValue,
+    UnaryOperator as LocalUnaryOperator,
+};
+use crate::logical_plan::{
+    AggregateExpr, AggregateFunction, Assignment, JoinType, LogicalPlan, SortExpr,
+};
+use crate::schema::{ColumnDef, DataType as LocalDataType, DefaultValue};
+use anyhow::{bail, Context, Result};
+use sqlparser::ast::{
+    AssignmentTarget, BinaryOperator as SqlBinaryOp, ColumnOption, CreateTable,
+    DataType as SqlDataType, Delete, Expr as SqlExpr, FromTable, FunctionArg, FunctionArgExpr,
+    FunctionArguments, GroupByExpr, Insert, JoinConstraint, JoinOperator, ObjectName, OrderByExpr,
+    Query, SelectItem, SetExpr, Statement, TableFactor, TableWithJoins,
+    UnaryOperator as SqlUnaryOp, Value,
+};
+use std::collections::HashMap;
+
+pub struct LogicalPlanner {
+    table_aliases: HashMap<String, String>,
+}
+
+impl LogicalPlanner {
+    pub fn new() -> Self {
+        Self {
+            table_aliases: HashMap::new(),
+        }
+    }
+
+    pub fn plan_statement(&mut self, stmt: Statement) -> Result<LogicalPlan> {
+        self.table_aliases.clear();
+        match stmt {
+            Statement::Query(query) => self.plan_query(*query),
+            Statement::Insert(insert) => self.plan_insert(insert),
+            Statement::Update {
+                table,
+                assignments,
+                selection,
+                ..
+            } => {
+                // table is TableWithJoins, need to extract the first table
+                let tf = match &table {
+                    TableWithJoins { relation, joins } if joins.is_empty() => relation,
+                    _ => bail!("UPDATE only supports simple table references"),
+                };
+                self.plan_update(tf, assignments, selection)
+            }
+            Statement::Delete(delete) => self.plan_delete(delete),
+            Statement::CreateTable(ct) => self.plan_create_table(ct),
+            Statement::Drop {
+                object_type,
+                if_exists,
+                names,
+                ..
+            } => self.plan_drop(object_type, names, if_exists),
+            _ => bail!("Unsupported statement type: {:?}", stmt),
+        }
+    }
+
+    fn plan_query(&mut self, query: Query) -> Result<LogicalPlan> {
+        let order_by = query.order_by;
+        let limit = query.limit.map(|e| self.parse_limit_expr(e)).transpose()?;
+        let offset = query
+            .offset
+            .map(|o| self.parse_limit_expr(o.value))
+            .transpose()?;
+        let select = match *query.body {
+            SetExpr::Select(s) => s,
+            SetExpr::Query(q) => return self.plan_query(*q),
+            _ => bail!("UNION/INTERSECT/EXCEPT not yet supported"),
+        };
+        let mut plan = self.plan_from_clause(&select.from)?;
+        if let Some(selection) = select.selection {
+            let predicate = self.plan_expr(selection)?;
+            self.validate_filter_predicate(&predicate, &plan)?;
+            plan = LogicalPlan::Filter {
+                input: Box::new(plan),
+                predicate,
+            };
+        }
+        match &select.group_by {
+            GroupByExpr::Expressions(exprs, _) if !exprs.is_empty() => {
+                let group_by_exprs: Result<Vec<_>> =
+                    exprs.iter().map(|e| self.plan_expr(e.clone())).collect();
+                let group_by_exprs = group_by_exprs?;
+                let aggregates = self.extract_aggregates(&select.projection)?;
+                plan = LogicalPlan::Aggregate {
+                    input: Box::new(plan),
+                    group_by: group_by_exprs,
+                    aggregates,
+                };
+            }
+            _ => {}
+        }
+        if let Some(having) = select.having {
+            let predicate = self.plan_expr(having)?;
+            plan = LogicalPlan::Filter {
+                input: Box::new(plan),
+                predicate,
+            };
+        }
+        let (expressions, aliases) = self.plan_select_items(&select.projection)?;
+        plan = LogicalPlan::Project {
+            input: Box::new(plan),
+            expressions,
+            aliases: if aliases.is_empty() {
+                None
+            } else {
+                Some(aliases)
+            },
+        };
+        if let Some(order) = order_by {
+            let sort_exprs: Result<Vec<_>> = order
+                .exprs
+                .iter()
+                .map(|o| self.plan_order_by_expr(o))
+                .collect();
+            let sort_exprs = sort_exprs?;
+            plan = LogicalPlan::Sort {
+                input: Box::new(plan),
+                sort_exprs,
+            };
+        }
+        if limit.is_some() || offset.is_some() {
+            plan = LogicalPlan::Limit {
+                input: Box::new(plan),
+                offset,
+                limit,
+            };
+        }
+        Ok(plan)
+    }
+
+    fn plan_from_clause(&mut self, from: &[TableWithJoins]) -> Result<LogicalPlan> {
+        if from.is_empty() {
+            bail!("SELECT without FROM clause not supported");
+        }
+        if from.len() > 1 {
+            bail!("Multiple comma-separated tables not supported [use JOIN]");
+        }
+        let twj = &from[0];
+        let mut plan = self.plan_table_factor(&twj.relation)?;
+        for join in &twj.joins {
+            let right = self.plan_table_factor(&join.relation)?;
+            let (join_type, condition) = match &join.join_operator {
+                JoinOperator::Inner(constraint) => {
+                    (JoinType::Inner, self.plan_join_constraint(constraint)?)
+                }
+                JoinOperator::LeftOuter(constraint) => {
+                    (JoinType::Left, self.plan_join_constraint(constraint)?)
+                }
+                JoinOperator::RightOuter(constraint) => {
+                    (JoinType::Right, self.plan_join_constraint(constraint)?)
+                }
+                JoinOperator::FullOuter(constraint) => {
+                    (JoinType::Full, self.plan_join_constraint(constraint)?)
+                }
+                JoinOperator::CrossJoin => (JoinType::Cross, None),
+                _ => bail!("Unsupported join type: {:?}", join.join_operator),
+            };
+            if let Some(ref cond) = condition {
+                self.validate_join_condition(cond, &plan, &right)?;
+            }
+            plan = LogicalPlan::Join {
+                left: Box::new(plan),
+                right: Box::new(right),
+                join_type,
+                condition,
+            };
+        }
+        Ok(plan)
+    }
+
+    fn plan_table_factor(&mut self, tf: &TableFactor) -> Result<LogicalPlan> {
+        match tf {
+            TableFactor::Table { name, alias, .. } => {
+                let tbl = object_name_to_string(name);
+                let alias_name = alias.as_ref().map(|a| a.name.value.clone());
+                if let Some(ref a) = alias_name {
+                    self.table_aliases.insert(a.clone(), tbl.clone());
+                }
+                Ok(LogicalPlan::Scan {
+                    table_name: tbl,
+                    alias: alias_name,
+                    schema: None,
+                })
+            }
+            TableFactor::Derived {
+                subquery, alias, ..
+            } => {
+                let subplan = self.plan_query(*subquery.clone())?;
+                if let Some(a) = alias {
+                    let alias_name = a.name.value.clone();
+                    self.table_aliases
+                        .insert(alias_name.clone(), "subquery".to_string());
+                }
+                Ok(subplan)
+            }
+            _ => bail!("Only simple table references and subqueries supported in FROM"),
+        }
+    }
+
+    fn plan_join_constraint(&mut self, constraint: &JoinConstraint) -> Result<Option<LocalExpr>> {
+        match constraint {
+            JoinConstraint::On(expr) => Ok(Some(self.plan_expr(expr.clone())?)),
+            JoinConstraint::None => Ok(None),
+            JoinConstraint::Using(_) => bail!("USING clause not yet supported"),
+            _ => bail!("Unsupported join constraint: {:?}", constraint),
+        }
+    }
+
+    fn plan_select_items(&mut self, items: &[SelectItem]) -> Result<(Vec<LocalExpr>, Vec<String>)> {
+        let mut expressions = Vec::new();
+        let mut aliases = Vec::new();
+        for item in items {
+            match item {
+                SelectItem::UnnamedExpr(expr) => {
+                    let planned = self.plan_expr(expr.clone())?;
+                    let alias = format!("{}", planned);
+                    expressions.push(planned);
+                    aliases.push(alias);
+                }
+                SelectItem::ExprWithAlias { expr, alias } => {
+                    expressions.push(self.plan_expr(expr.clone())?);
+                    aliases.push(alias.value.clone());
+                }
+                SelectItem::Wildcard(_) => {
+                    expressions.push(LocalExpr::Wildcard);
+                    aliases.push("*".to_string());
+                }
+                SelectItem::QualifiedWildcard(obj_name, _) => {
+                    let table = object_name_to_string(obj_name);
+                    expressions.push(LocalExpr::QualifiedWildcard {
+                        table: table.clone(),
+                    });
+                    aliases.push(format!("{}.*", table));
+                }
+            }
+        }
+        Ok((expressions, aliases))
+    }
+
+    fn plan_expr(&mut self, expr: SqlExpr) -> Result<LocalExpr> {
+        match expr {
+            SqlExpr::Identifier(ident) => Ok(LocalExpr::Column {
+                table: None,
+                name: ident.value,
+            }),
+            SqlExpr::CompoundIdentifier(idents) => {
+                if idents.len() == 2 {
+                    Ok(LocalExpr::Column {
+                        table: Some(idents[0].value.clone()),
+                        name: idents[1].value.clone(),
+                    })
+                } else if idents.len() == 3 {
+                    Ok(LocalExpr::Column {
+                        table: Some(idents[1].value.clone()),
+                        name: idents[2].value.clone(),
+                    })
+                } else {
+                    bail!(
+                        "Unsupported compound identifier with {} parts",
+                        idents.len()
+                    );
+                }
+            }
+            SqlExpr::Value(value) => Ok(LocalExpr::Literal(self.plan_value(value)?)),
+            SqlExpr::BinaryOp { left, op, right } => Ok(LocalExpr::BinaryOp {
+                left: Box::new(self.plan_expr(*left)?),
+                op: self.convert_binary_op(op)?,
+                right: Box::new(self.plan_expr(*right)?),
+            }),
+            SqlExpr::UnaryOp { op, expr } => Ok(LocalExpr::UnaryOp {
+                op: self.convert_unary_op(op)?,
+                expr: Box::new(self.plan_expr(*expr)?),
+            }),
+            SqlExpr::Cast {
+                expr, data_type, ..
+            } => Ok(LocalExpr::Cast {
+                expr: Box::new(self.plan_expr(*expr)?),
+                target_type: self.convert_data_type(&data_type)?,
+            }),
+            SqlExpr::IsNull(expr) => Ok(LocalExpr::IsNull {
+                expr: Box::new(self.plan_expr(*expr)?),
+                negated: false,
+            }),
+            SqlExpr::IsNotNull(expr) => Ok(LocalExpr::IsNull {
+                expr: Box::new(self.plan_expr(*expr)?),
+                negated: true,
+            }),
+            SqlExpr::Between {
+                expr,
+                low,
+                high,
+                negated,
+            } => Ok(LocalExpr::Between {
+                expr: Box::new(self.plan_expr(*expr)?),
+                low: Box::new(self.plan_expr(*low)?),
+                high: Box::new(self.plan_expr(*high)?),
+                negated,
+            }),
+            SqlExpr::InList {
+                expr,
+                list,
+                negated,
+            } => {
+                let planned_list: Result<Vec<_>> =
+                    list.into_iter().map(|e| self.plan_expr(e)).collect();
+                Ok(LocalExpr::In {
+                    expr: Box::new(self.plan_expr(*expr)?),
+                    list: planned_list?,
+                    negated,
+                })
+            }
+            SqlExpr::Function(func) => {
+                let name = object_name_to_string(&func.name);
+                let args = match &func.args {
+                    FunctionArguments::List(args) => args
+                        .args
+                        .iter()
+                        .map(|arg| self.plan_function_arg(arg))
+                        .collect::<Result<Vec<_>>>()?,
+                    FunctionArguments::None => Vec::new(),
+                    FunctionArguments::Subquery(_) => {
+                        bail!("Subquery function arguments not supported")
+                    }
+                };
+                Ok(LocalExpr::Function {
+                    name: name.to_uppercase(),
+                    args,
+                })
+            }
+            SqlExpr::Nested(expr) => self.plan_expr(*expr),
+            _ => bail!("Unsupported expression type: {:?}", expr),
+        }
+    }
+
+    fn plan_function_arg(&mut self, arg: &FunctionArg) -> Result<LocalExpr> {
+        match arg {
+            FunctionArg::Unnamed(expr_or_wildcard) => match expr_or_wildcard {
+                FunctionArgExpr::Expr(e) => self.plan_expr(e.clone()),
+                FunctionArgExpr::Wildcard => Ok(LocalExpr::Wildcard),
+                FunctionArgExpr::QualifiedWildcard(name) => {
+                    let table = object_name_to_string(name);
+                    Ok(LocalExpr::QualifiedWildcard { table })
+                }
+            },
+            FunctionArg::Named { name: _, arg, .. } => match arg {
+                FunctionArgExpr::Expr(e) => self.plan_expr(e.clone()),
+                FunctionArgExpr::Wildcard => Ok(LocalExpr::Wildcard),
+                FunctionArgExpr::QualifiedWildcard(name) => {
+                    let table = object_name_to_string(name);
+                    Ok(LocalExpr::QualifiedWildcard { table })
+                }
+            },
+        }
+    }
+
+    fn plan_value(&self, value: Value) -> Result<LiteralValue> {
+        match value {
+            Value::Number(s, _) => {
+                if s.contains('.') || s.contains('e') || s.contains('E') {
+                    Ok(LiteralValue::Float(s.parse().context("Invalid float")?))
+                } else {
+                    Ok(LiteralValue::Integer(s.parse().context("Invalid integer")?))
+                }
+            }
+            Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => {
+                Ok(LiteralValue::String(s))
+            }
+            Value::Boolean(b) => Ok(LiteralValue::Boolean(b)),
+            Value::Null => Ok(LiteralValue::Null),
+            _ => bail!("Unsupported literal value: {:?}", value),
+        }
+    }
+
+    fn convert_binary_op(&self, op: SqlBinaryOp) -> Result<LocalBinaryOperator> {
+        Ok(match op {
+            SqlBinaryOp::Plus => LocalBinaryOperator::Plus,
+            SqlBinaryOp::Minus => LocalBinaryOperator::Minus,
+            SqlBinaryOp::Multiply => LocalBinaryOperator::Multiply,
+            SqlBinaryOp::Divide => LocalBinaryOperator::Divide,
+            SqlBinaryOp::Modulo => LocalBinaryOperator::Modulo,
+            SqlBinaryOp::Eq => LocalBinaryOperator::Eq,
+            SqlBinaryOp::NotEq => LocalBinaryOperator::NotEq,
+            SqlBinaryOp::Lt => LocalBinaryOperator::Lt,
+            SqlBinaryOp::LtEq => LocalBinaryOperator::LtEq,
+            SqlBinaryOp::Gt => LocalBinaryOperator::Gt,
+            SqlBinaryOp::GtEq => LocalBinaryOperator::GtEq,
+            SqlBinaryOp::And => LocalBinaryOperator::And,
+            SqlBinaryOp::Or => LocalBinaryOperator::Or,
+            SqlBinaryOp::StringConcat => LocalBinaryOperator::Concat,
+            _ => bail!("Unsupported binary operator: {:?}", op),
+        })
+    }
+
+    fn convert_unary_op(&self, op: SqlUnaryOp) -> Result<LocalUnaryOperator> {
+        Ok(match op {
+            SqlUnaryOp::Not => LocalUnaryOperator::Not,
+            SqlUnaryOp::Minus => LocalUnaryOperator::Minus,
+            SqlUnaryOp::Plus => LocalUnaryOperator::Plus,
+            _ => bail!("Unsupported unary operator: {:?}", op),
+        })
+    }
+
+    fn convert_data_type(&self, dt: &SqlDataType) -> Result<LocalDataType> {
+        Ok(match dt {
+            SqlDataType::Int(_) | SqlDataType::Integer(_) => LocalDataType::Integer,
+            SqlDataType::BigInt(_) => LocalDataType::BigInt,
+            SqlDataType::Real | SqlDataType::Float(_) | SqlDataType::Double => LocalDataType::Real,
+            SqlDataType::Varchar(_) | SqlDataType::Text | SqlDataType::String(_) => {
+                LocalDataType::Text
+            }
+            SqlDataType::Boolean => LocalDataType::Boolean,
+            SqlDataType::Timestamp(_, _) => LocalDataType::Timestamp,
+            _ => bail!("Unsupported data type: {:?}", dt),
+        })
+    }
+
+    fn plan_insert(&mut self, ins: Insert) -> Result<LogicalPlan> {
+        let table = object_name_to_string(&ins.table_name);
+        let column_names = if ins.columns.is_empty() {
+            None
+        } else {
+            Some(ins.columns.into_iter().map(|c| c.value).collect())
+        };
+        if let Some(query) = ins.source {
+            if let SetExpr::Values(values) = *query.body {
+                let rows: Result<Vec<Vec<LocalExpr>>> = values
+                    .rows
+                    .into_iter()
+                    .map(|row| row.into_iter().map(|e| self.plan_expr(e)).collect())
+                    .collect();
+                return Ok(LogicalPlan::Insert {
+                    table_name: table,
+                    columns: column_names,
+                    values: rows?,
+                    schema: None,
+                });
+            }
+            bail!("INSERT ... SELECT not yet supported");
+        }
+        bail!("INSERT requires VALUES clause");
+    }
+
+    fn plan_update(
+        &mut self,
+        table: &TableFactor,
+        assignments: Vec<sqlparser::ast::Assignment>,
+        selection: Option<SqlExpr>,
+    ) -> Result<LogicalPlan> {
+        let table_name = match table {
+            TableFactor::Table { name, .. } => object_name_to_string(name),
+            _ => bail!("UPDATE only supports simple table references"),
+        };
+        let planned_assignments: Result<Vec<_>> = assignments
+            .into_iter()
+            .map(|a| {
+                let col = match &a.target {
+                    AssignmentTarget::ColumnName(name) => object_name_to_string(name),
+                    _ => bail!("Only column assignments supported"),
+                };
+                let value = self.plan_expr(a.value)?;
+                Ok(Assignment { column: col, value })
+            })
+            .collect();
+        let filter = selection.map(|e| self.plan_expr(e)).transpose()?;
+        Ok(LogicalPlan::Update {
+            table_name,
+            assignments: planned_assignments?,
+            filter,
+            schema: None,
+        })
+    }
+
+    fn plan_delete(&mut self, del: Delete) -> Result<LogicalPlan> {
+        let tables = match &del.from {
+            FromTable::WithFromKeyword(tables) => tables,
+            FromTable::WithoutKeyword(tables) => tables,
+        };
+        if tables.len() != 1 {
+            bail!("DELETE only supports single table");
+        }
+        let table_name = match &tables[0] {
+            TableWithJoins {
+                relation: TableFactor::Table { name, .. },
+                joins,
+            } if joins.is_empty() => object_name_to_string(name),
+            _ => bail!("DELETE only supports simple table references"),
+        };
+        let filter = del.selection.map(|e| self.plan_expr(e)).transpose()?;
+        Ok(LogicalPlan::Delete {
+            table_name,
+            filter,
+            schema: None,
+        })
+    }
+
+    fn plan_create_table(&mut self, ct: CreateTable) -> Result<LogicalPlan> {
+        let table_name = object_name_to_string(&ct.name);
+        let column_defs: Result<Vec<_>> = ct
+            .columns
+            .into_iter()
+            .map(|col| {
+                let data_type = self.convert_data_type(&col.data_type)?;
+                let mut nullable = true;
+                let mut primary_key = false;
+                let mut default_value = None;
+                for option in col.options {
+                    match option.option {
+                        ColumnOption::Null => nullable = true,
+                        ColumnOption::NotNull => nullable = false,
+                        ColumnOption::Unique { is_primary, .. } => {
+                            if is_primary {
+                                primary_key = true;
+                                nullable = false;
+                            }
+                        }
+                        ColumnOption::Default(expr) => {
+                            default_value = Some(self.plan_expr_to_default(expr)?);
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(ColumnDef {
+                    name: col.name.value,
+                    data_type,
+                    nullable,
+                    primary_key,
+                    default_value,
+                })
+            })
+            .collect();
+        Ok(LogicalPlan::CreateTable {
+            table_name,
+            columns: column_defs?,
+            if_not_exists: ct.if_not_exists,
+        })
+    }
+
+    fn plan_drop(
+        &mut self,
+        object_type: sqlparser::ast::ObjectType,
+        names: Vec<ObjectName>,
+        if_exists: bool,
+    ) -> Result<LogicalPlan> {
+        match object_type {
+            sqlparser::ast::ObjectType::Table => {
+                if names.len() != 1 {
+                    bail!("DROP TABLE only supports single table");
+                }
+                Ok(LogicalPlan::DropTable {
+                    table_name: object_name_to_string(&names[0]),
+                    if_exists,
+                })
+            }
+            _ => bail!("Only DROP TABLE supported"),
+        }
+    }
+
+    fn plan_expr_to_default(&mut self, expr: SqlExpr) -> Result<DefaultValue> {
+        match expr {
+            SqlExpr::Value(Value::Null) => Ok(DefaultValue::Null),
+            SqlExpr::Value(Value::Number(s, _)) => {
+                if s.contains('.') {
+                    Ok(DefaultValue::Real(s.parse()?))
+                } else {
+                    Ok(DefaultValue::Integer(s.parse()?))
+                }
+            }
+            SqlExpr::Value(Value::SingleQuotedString(s)) => Ok(DefaultValue::Text(s)),
+            SqlExpr::Value(Value::Boolean(b)) => Ok(DefaultValue::Boolean(b)),
+            SqlExpr::Function(f)
+                if object_name_to_string(&f.name).to_uppercase() == "CURRENT_TIMESTAMP" =>
+            {
+                Ok(DefaultValue::CurrentTimestamp)
+            }
+            _ => bail!("Unsupported default value expression: {:?}", expr),
+        }
+    }
+
+    fn parse_limit_expr(&mut self, expr: SqlExpr) -> Result<usize> {
+        match expr {
+            SqlExpr::Value(Value::Number(s, _)) => {
+                Ok(s.parse().context("Invalid LIMIT/OFFSET value")?)
+            }
+            _ => bail!("LIMIT/OFFSET must be a number"),
+        }
+    }
+
+    fn plan_order_by_expr(&mut self, order: &OrderByExpr) -> Result<SortExpr> {
+        Ok(SortExpr {
+            expr: self.plan_expr(order.expr.clone())?,
+            asc: order.asc.unwrap_or(true),
+            nulls_first: order.nulls_first.unwrap_or(false),
+        })
+    }
+
+    fn extract_aggregates(&mut self, items: &[SelectItem]) -> Result<Vec<AggregateExpr>> {
+        let mut aggregates = Vec::new();
+        for item in items {
+            match item {
+                SelectItem::UnnamedExpr(expr) | SelectItem::ExprWithAlias { expr, .. } => {
+                    if let Some(agg) = self.extract_aggregate_from_expr(expr)? {
+                        aggregates.push(agg);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(aggregates)
+    }
+
+    fn extract_aggregate_from_expr(&mut self, expr: &SqlExpr) -> Result<Option<AggregateExpr>> {
+        match expr {
+            SqlExpr::Function(func) => {
+                let name = object_name_to_string(&func.name).to_uppercase();
+                let agg_func = match name.as_str() {
+                    "COUNT" => AggregateFunction::Count,
+                    "SUM" => AggregateFunction::Sum,
+                    "AVG" => AggregateFunction::Avg,
+                    "MIN" => AggregateFunction::Min,
+                    "MAX" => AggregateFunction::Max,
+                    _ => return Ok(None),
+                };
+                let args = match &func.args {
+                    FunctionArguments::List(args) => args
+                        .args
+                        .iter()
+                        .map(|arg| self.plan_function_arg(arg))
+                        .collect::<Result<Vec<_>>>()?,
+                    FunctionArguments::None => Vec::new(),
+                    FunctionArguments::Subquery(_) => bail!("Subquery in aggregate not supported"),
+                };
+                Ok(Some(AggregateExpr {
+                    func: agg_func,
+                    args,
+                    alias: None,
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    fn validate_filter_predicate(&self, predicate: &LocalExpr, _input: &LogicalPlan) -> Result<()> {
+        self.validate_expr_well_formed(predicate)
+    }
+
+    fn validate_join_condition(
+        &self,
+        condition: &LocalExpr,
+        _left: &LogicalPlan,
+        _right: &LogicalPlan,
+    ) -> Result<()> {
+        self.validate_expr_well_formed(condition)
+    }
+
+    fn validate_expr_well_formed(&self, expr: &LocalExpr) -> Result<()> {
+        match expr {
+            LocalExpr::Column { .. }
+            | LocalExpr::Literal(_)
+            | LocalExpr::Wildcard
+            | LocalExpr::QualifiedWildcard { .. } => Ok(()),
+            LocalExpr::BinaryOp { left, right, .. } => {
+                self.validate_expr_well_formed(left)?;
+                self.validate_expr_well_formed(right)
+            }
+            LocalExpr::UnaryOp { expr, .. } => self.validate_expr_well_formed(expr),
+            LocalExpr::Function { args, .. } => {
+                for arg in args {
+                    self.validate_expr_well_formed(arg)?;
+                }
+                Ok(())
+            }
+            LocalExpr::Cast { expr, .. } => self.validate_expr_well_formed(expr),
+            LocalExpr::IsNull { expr, .. } => self.validate_expr_well_formed(expr),
+            LocalExpr::Between {
+                expr, low, high, ..
+            } => {
+                self.validate_expr_well_formed(expr)?;
+                self.validate_expr_well_formed(low)?;
+                self.validate_expr_well_formed(high)
+            }
+            LocalExpr::In { expr, list, .. } => {
+                self.validate_expr_well_formed(expr)?;
+                for item in list {
+                    self.validate_expr_well_formed(item)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl Default for LogicalPlanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn object_name_to_string(name: &ObjectName) -> String {
+    name.0
+        .iter()
+        .map(|ident| ident.value.clone())
+        .collect::<Vec<_>>()
+        .join(".")
+}

--- a/crates/query/src/schema.rs
+++ b/crates/query/src/schema.rs
@@ -1,0 +1,119 @@
+/// Represents a SQL data type
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DataType {
+    Integer,
+    BigInt,
+    Real,
+    Text,
+    Boolean,
+    Timestamp,
+}
+
+impl DataType {
+    pub fn fixed_size(&self) -> Option<usize> {
+        match self {
+            DataType::Integer => Some(4),
+            DataType::BigInt => Some(8),
+            DataType::Real => Some(8),
+            DataType::Boolean => Some(1),
+            DataType::Timestamp => Some(8),
+            DataType::Text => None,
+        }
+    }
+    pub fn is_nullable_by_default(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColumnDef {
+    pub name: String,
+    pub data_type: DataType,
+    pub nullable: bool,
+    pub primary_key: bool,
+    pub default_value: Option<DefaultValue>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DefaultValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Boolean(bool),
+    CurrentTimestamp,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TableSchema {
+    pub table_name: String,
+    pub columns: Vec<ColumnDef>,
+}
+
+impl TableSchema {
+    pub fn new(table_name: String, columns: Vec<ColumnDef>) -> Self {
+        Self {
+            table_name,
+            columns,
+        }
+    }
+    pub fn find_column(&self, name: &str) -> Option<&ColumnDef> {
+        self.columns
+            .iter()
+            .find(|col| col.name.eq_ignore_ascii_case(name))
+    }
+    pub fn column_index(&self, name: &str) -> Option<usize> {
+        self.columns
+            .iter()
+            .position(|col| col.name.eq_ignore_ascii_case(name))
+    }
+    pub fn column_names(&self) -> Vec<String> {
+        self.columns.iter().map(|c| c.name.clone()).collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Schema {
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Field {
+    pub name: String,
+    pub table: Option<String>,
+    pub data_type: DataType,
+    pub nullable: bool,
+}
+
+impl Schema {
+    pub fn empty() -> Self {
+        Self { fields: Vec::new() }
+    }
+    pub fn new(fields: Vec<Field>) -> Self {
+        Self { fields }
+    }
+    pub fn find_field(&self, name: &str) -> Option<&Field> {
+        if let Some(field) = self
+            .fields
+            .iter()
+            .find(|f| f.name.eq_ignore_ascii_case(name))
+        {
+            return Some(field);
+        }
+        if let Some(field) = self.fields.iter().find(|f| {
+            f.name
+                .split('.')
+                .next_back()
+                .unwrap_or("")
+                .eq_ignore_ascii_case(name)
+        }) {
+            return Some(field);
+        }
+        None
+    }
+    pub fn field_index(&self, name: &str) -> Option<usize> {
+        self.fields
+            .iter()
+            .position(|f| f.name.eq_ignore_ascii_case(name))
+    }
+}

--- a/crates/query/tests/acceptance.rs
+++ b/crates/query/tests/acceptance.rs
@@ -1,0 +1,260 @@
+//! Acceptance tests for Issue 1.2
+use query::{explain_sql, sql_to_logical_plan, JoinType, LogicalPlan};
+
+#[test]
+fn acceptance_sql_to_logical_plan_pipeline() {
+    let sql = "SELECT * FROM Event e JOIN TicketType t ON e.id = t.eventId";
+    let result = sql_to_logical_plan(sql);
+    assert!(result.is_ok(), "Failed to parse and plan valid SQL");
+}
+
+#[test]
+fn acceptance_invalid_sql_fails_gracefully() {
+    let invalid_sqls = vec![
+        "SELECT FROM WHERE",
+        "INSERT INTO",
+        "UPDATE SET x = 1",
+        "DELETE FROM WHERE x = 1",
+        "CREATE TABLE",
+        "INVALID QUERY",
+    ];
+    for sql in invalid_sqls {
+        let result = sql_to_logical_plan(sql);
+        assert!(result.is_err(), "Should fail for: {}", sql);
+        let err = result.unwrap_err();
+        let err_msg = format!("{}", err);
+        assert!(!err_msg.is_empty(), "Error message should not be empty");
+    }
+}
+
+#[test]
+fn acceptance_joins_explicitly_represented() {
+    let sql = "SELECT * FROM Event e JOIN TicketType t ON e.id = t.eventId";
+    let plan = sql_to_logical_plan(sql).unwrap();
+    let mut found_join = false;
+    let mut current = &plan;
+    loop {
+        match current {
+            LogicalPlan::Join {
+                join_type,
+                condition,
+                left,
+                right,
+            } => {
+                assert_eq!(*join_type, JoinType::Inner);
+                assert!(condition.is_some(), "Join condition must be present");
+                assert!(matches!(**left, LogicalPlan::Scan { .. }));
+                assert!(matches!(**right, LogicalPlan::Scan { .. }));
+                found_join = true;
+                break;
+            }
+            LogicalPlan::Project { input, .. } => {
+                current = input;
+            }
+            _ => break,
+        }
+    }
+    assert!(
+        found_join,
+        "JOIN must be explicitly represented in plan tree"
+    );
+}
+
+#[test]
+fn acceptance_explain_readable_output() {
+    let sql = "SELECT * FROM Event e JOIN TicketType t ON e.id = t.eventId";
+    let plan = sql_to_logical_plan(sql).unwrap();
+    let explanation = plan.explain();
+    assert!(explanation.contains("Join"), "Must show Join operator");
+    assert!(explanation.contains("INNER"), "Must show join type");
+    assert!(explanation.contains("Event"), "Must show left table");
+    assert!(explanation.contains("TicketType"), "Must show right table");
+    assert!(explanation.contains("Scan"), "Must show Scan operations");
+    assert!(
+        explanation.lines().count() > 1,
+        "Should have tree structure"
+    );
+    println!("EXPLAIN output:\n{}", explanation);
+}
+
+#[test]
+fn acceptance_all_sql_operations_supported() {
+    assert!(sql_to_logical_plan("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)").is_ok());
+    assert!(sql_to_logical_plan("INSERT INTO users (id, name) VALUES (1, 'Alice')").is_ok());
+    assert!(sql_to_logical_plan("SELECT * FROM users").is_ok());
+    assert!(sql_to_logical_plan("SELECT name FROM users WHERE id = 1").is_ok());
+    assert!(sql_to_logical_plan("SELECT * FROM users u JOIN orders o ON u.id = o.user_id").is_ok());
+    assert!(sql_to_logical_plan("UPDATE users SET name = 'Bob' WHERE id = 1").is_ok());
+    assert!(sql_to_logical_plan("DELETE FROM users WHERE id = 1").is_ok());
+}
+
+#[test]
+fn measurable_proof_explain_join() {
+    let sql = "SELECT * FROM Event e JOIN TicketType t ON e.id = t.eventId";
+    let plan = sql_to_logical_plan(sql).expect("Failed to parse and plan");
+    let output = plan.explain();
+    println!("\n=== MEASURABLE PROOF ===");
+    println!("SQL: {}", sql);
+    println!("\nEXPLAIN output:");
+    println!("{}", output);
+    println!("========================\n");
+    assert!(output.contains("Join"));
+    assert!(output.contains("INNER") || output.contains("Inner"));
+    assert!(output.contains("Event"));
+    assert!(output.contains("TicketType"));
+    assert!(output.contains("ON") || output.contains("e.id"));
+}
+
+// Edge Case Tests
+
+#[test]
+fn test_operator_precedence() {
+    let sql = "SELECT a + b * c FROM t";
+    let plan = sql_to_logical_plan(sql).expect("Should parse precedence correctly");
+    assert!(matches!(plan, LogicalPlan::Project { .. }));
+
+    let sql2 = "SELECT a * b + c FROM t";
+    let plan2 = sql_to_logical_plan(sql2).expect("Should parse precedence correctly");
+    assert!(matches!(plan2, LogicalPlan::Project { .. }));
+
+    let sql3 = "SELECT a AND b OR c FROM t";
+    let plan3 = sql_to_logical_plan(sql3).expect("Should parse logical precedence");
+    assert!(matches!(plan3, LogicalPlan::Project { .. }));
+
+    // SQL standard: AND binds tighter than OR.
+    // Should be parsed as: x OR (y AND z)
+    let sql4 = "SELECT * FROM t WHERE x = 1 OR y = 2 AND z = 3";
+    let explained = explain_sql(sql4).unwrap();
+
+    // In the explanation, the tree structure usually groups inner expressions first.
+    // We look for the structure (y = 2 AND z = 3) inside the OR.
+    // Note: The specific string format depends on your Display impl, but conceptually:
+    println!("{}", explained);
+    assert!(explained.contains("OR"));
+    assert!(explained.contains("AND"));
+    // This is a semantic check you might need to inspect the plan manually for
+    // or ensure your Display impl uses parentheses for groups.
+
+    println!("Operator precedence tests passed");
+}
+
+#[test]
+fn test_table_and_column_aliasing() {
+    let sql = "SELECT u.id, u.name FROM users AS u";
+    let plan = sql_to_logical_plan(sql).expect("Should parse table alias");
+    if let LogicalPlan::Project { aliases, .. } = &plan {
+        assert!(aliases.is_some(), "Should have aliases");
+    }
+
+    let sql2 = "SELECT id AS user_id, name AS user_name FROM users";
+    let plan2 = sql_to_logical_plan(sql2).expect("Should parse column aliases");
+    if let LogicalPlan::Project { aliases, .. } = &plan2 {
+        assert!(aliases.is_some(), "Should have column aliases");
+        let alias_vec = aliases.as_ref().unwrap();
+        assert!(alias_vec.iter().any(|a| a == "user_id"));
+        assert!(alias_vec.iter().any(|a| a == "user_name"));
+    }
+
+    let sql3 = "SELECT t.id, t.name FROM users t";
+    let plan3 = sql_to_logical_plan(sql3).expect("Should parse implicit table alias");
+    assert!(matches!(plan3, LogicalPlan::Project { .. }));
+
+    let sql4 = "SELECT u.name, o.id FROM users u JOIN orders o ON u.id = o.user_id";
+    let plan = sql_to_logical_plan(sql4).unwrap();
+    let explained = plan.explain();
+
+    assert!(explained.contains("Scan: users (alias: u)"));
+    assert!(explained.contains("Scan: orders (alias: o)"));
+    assert!(
+        explained.contains("ON (u.id = o.user_id)"),
+        "JOIN condition should show with parentheses"
+    );
+
+    println!("Aliasing tests passed");
+}
+
+#[test]
+fn test_casting_and_literals() {
+    let sql = "SELECT CAST(id AS TEXT) FROM users";
+    let plan = sql_to_logical_plan(sql).expect("Should parse CAST");
+    assert!(matches!(plan, LogicalPlan::Project { .. }));
+
+    let sql2 = "SELECT 'hello world' AS greeting FROM users";
+    let plan2 = sql_to_logical_plan(sql2).expect("Should parse string literal");
+    assert!(matches!(plan2, LogicalPlan::Project { .. }));
+
+    let sql3 = "SELECT 42 AS answer, 3.14 AS pi FROM users";
+    let plan3 = sql_to_logical_plan(sql3).expect("Should parse numeric literals");
+    assert!(matches!(plan3, LogicalPlan::Project { .. }));
+
+    let sql4 = "SELECT TRUE AS is_active, FALSE AS is_deleted FROM users";
+    let plan4 = sql_to_logical_plan(sql4).expect("Should parse boolean literals");
+    assert!(matches!(plan4, LogicalPlan::Project { .. }));
+
+    let sql5 = "SELECT CAST(price AS INTEGER) FROM products";
+    let plan5 = sql_to_logical_plan(sql5).expect("Should parse CAST with INTEGER");
+    assert!(matches!(plan5, LogicalPlan::Project { .. }));
+
+    let sql6 = "SELECT CAST(price AS REAL), 'active' FROM products WHERE is_sale = true";
+    let explained = explain_sql(sql6).unwrap();
+
+    assert!(explained.contains("CAST(price AS Real)"));
+    assert!(explained.contains("'active'")); // String literal
+    assert!(explained.contains("true")); // Boolean literal
+
+    println!("Casting and literals tests passed");
+}
+
+#[test]
+fn test_aggregation_and_group_by() {
+    fn find_aggregate(plan: &LogicalPlan) -> bool {
+        match plan {
+            LogicalPlan::Aggregate { .. } => true,
+            LogicalPlan::Project { input, .. } => find_aggregate(input),
+            _ => false,
+        }
+    }
+
+    let sql = "SELECT COUNT(*) FROM users GROUP BY department";
+    let plan = sql_to_logical_plan(sql).expect("Should parse GROUP BY");
+    assert!(
+        find_aggregate(&plan),
+        "GROUP BY should create Aggregate node in tree"
+    );
+
+    let sql2 = "SELECT AVG(age), COUNT(*) FROM users GROUP BY department";
+    let plan2 = sql_to_logical_plan(sql2).expect("Should parse GROUP BY with multiple aggs");
+    assert!(find_aggregate(&plan2));
+
+    let sql3 = "SELECT department, COUNT(*) FROM users GROUP BY department";
+    let plan3 = sql_to_logical_plan(sql3).expect("Should parse GROUP BY with column");
+    assert!(find_aggregate(&plan3));
+
+    println!("Aggregation tests passed");
+}
+
+#[test]
+fn test_subquery_in_from() {
+    let sql = "SELECT * FROM (SELECT id FROM users) AS sub_u WHERE id > 5";
+    let explained = explain_sql(sql).unwrap();
+
+    // Subqueries are inlined into the plan tree
+    // Structure: Project -> Filter -> Project -> Scan
+    // The alias 'sub_u' is used for column resolution but not shown in EXPLAIN
+    assert!(explained.contains("Project"), "Should have Project node");
+    assert!(
+        explained.contains("Filter"),
+        "Should have Filter node for WHERE"
+    );
+    assert!(
+        explained.contains("Scan: users"),
+        "Should have Scan for underlying table"
+    );
+    assert!(
+        explained.contains("Project:"),
+        "Should have inner Project for subquery SELECT"
+    );
+
+    println!("Subquery EXPLAIN:\n{}", explained);
+    println!("The 'Subquery' Test Passes");
+}


### PR DESCRIPTION
Complete Issue 1.2 - SQL Parser + Logical Planner
- Create `query` crate with sqlparser 0.52 integration
- Implement LogicalPlan enum (Scan, Filter, Project, Join, Sort, Limit, Aggregate, Insert, Update, Delete, CreateTable, DropTable)
- Build LogicalPlanner that translates SQL AST to logical query tree
- Add comprehensive edge case tests (operator precedence, aggregation, aliases, casting, subqueries)
- Add Dot (Graphviz) exporter for visualizing query plan trees
- Fix sqlparser 0.52 API mismatches (FromTable, FunctionArguments variants, etc.)
- Ensure clean clippy output with no warnings
Result: 20 tests passing (9 unit + 11 acceptance), all acceptance criteria met